### PR TITLE
vector notation

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## Unreleased
 
 - ![](https://img.shields.io/badge/new%20feature-green.svg) support for weighted rules.
+- ![](https://img.shields.io/badge/new%20feature-green.svg) allow to specify input and output variables as vectors (e.g. `x[1:10]`) and support for loops to avoid repetitive code.
 
 ## v0.1.1 -- 2023-02-25
 

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -49,6 +49,9 @@ function (fis::MamdaniFuzzySystem)(inputs::T) where {T <: NamedTuple}
 end
 
 (fis::MamdaniFuzzySystem)(; inputs...) = fis(values(inputs))
+@inline function (fis::MamdaniFuzzySystem)(inputs::Union{AbstractVector, Tuple})
+    fis((; zip(collect(keys(fis.inputs)), inputs)...))
+end
 
 function (fis::SugenoFuzzySystem)(inputs::T) where {T <: NamedTuple}
     S = float(eltype(T))
@@ -66,3 +69,6 @@ function (fis::SugenoFuzzySystem)(inputs::T) where {T <: NamedTuple}
 end
 
 (fis::SugenoFuzzySystem)(; inputs...) = fis(values(inputs))
+@inline function (fis::SugenoFuzzySystem)(inputs::Union{AbstractVector, Tuple})
+    fis((; zip(collect(keys(fis.inputs)), inputs)...))
+end

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -59,7 +59,7 @@ struct FuzzyRule{T <: AbstractFuzzyProposition} <: AbstractRule
     "consequences of the inference rule."
     consequent::Vector{FuzzyRelation}
 end
-Base.show(io::IO, r::FuzzyRule) = print(io, r.antecedent, " --> ", r.consequent...)
+Base.show(io::IO, r::FuzzyRule) = print(io, r.antecedent, " --> ", join(r.consequent, ", "))
 
 """
 Weighted fuzzy rule. In Mamdani systems, the result of implication is scaled by the weight.
@@ -75,7 +75,7 @@ struct WeightedFuzzyRule{T <: AbstractFuzzyProposition, S <: Real} <: AbstractRu
 end
 
 function Base.show(io::IO, r::WeightedFuzzyRule)
-    print(io, r.antecedent, " --> ", r.consequent..., " (", r.weight, ")")
+    print(io, r.antecedent, " --> ", join(r.consequent, ", "), " (", r.weight, ")")
 end
 
 @inline scale(w, ::FuzzyRule) = w

--- a/test/test_evaluation.jl
+++ b/test/test_evaluation.jl
@@ -60,6 +60,7 @@ using FuzzyLogic, Test
     end
 
     @test fis(service = 2, food = 7)[:tip]≈9.36 atol=1e-2
+    @test fis([2, 7])[:tip]≈9.36 atol=1e-2
 end
 
 @testset "test Sugeno evaluation" begin
@@ -116,4 +117,5 @@ end
         service == excellent || food == delicious --> tip == generous
     end
     @test fis2(service = 7, food = 8)[:tip]≈19.639 atol=1e-3
+    @test fis2((7, 8))[:tip]≈19.639 atol=1e-3
 end


### PR DESCRIPTION
- [x] fis accepts vectors as input
- [x] fis input and output variables can be defined as vector (e.g. `x[1:3]`)
- [x] for-loops in DSL to avoid repetitive patterns 